### PR TITLE
Bug fix: missing argument in assigning expiry time in rate-limiter

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 export const rateConfig = {
-  requestLimit: 15,
+  requestLimit: 100,
   timeLimit: 60,
 };
 export const costs = {

--- a/cost-assesser/cost-limiter.js
+++ b/cost-assesser/cost-limiter.js
@@ -5,7 +5,7 @@ import { parse } from 'graphql';
 // Main function to be added to middleware chain.
 export default function costLimiter(req, res, next) {
   // grab the query string off the request body
-  // console.log('body: ', req.body);
+  console.log('body: ', req.context);
   const { query } = req.body
   
   // if the query has content, parse the request into an object and assess it with helper function

--- a/rate-limiter/rate-limiter.js
+++ b/rate-limiter/rate-limiter.js
@@ -50,7 +50,7 @@ export default async function rateLimiter(req, res, next) {
   console.log('cost: ', res.locals.cost);
 
   const firstRequest = await redis.exists(ip);
-  if (!redis.exists) {
+  if (!redis.exists(ip)) {
     redis.expire(ip, rateConfig.timeLimit);
   }
 


### PR DESCRIPTION
Found and fixed bug from last PR preventing expiry time from being set in Redis cache for rate limiting.
Also increased rate limit in config -- was low before for demonstration purposes